### PR TITLE
Fix size px issue for SVG

### DIFF
--- a/tests/engines/test_base_engine.py
+++ b/tests/engines/test_base_engine.py
@@ -61,6 +61,7 @@ class BaseEngineTestCase(TestCase):
     def setUp(self):
         self.image = ((1, 2), (3, 4))
         self.context = self.get_context()
+        self.context.request = mock.MagicMock(width=0, height=0)
         self.engine = BaseEngine(self.context)
         self.engine.flip_horizontally = mock.MagicMock()
         self.engine.flip_horizontally.side_effect = self.flip_horizontally

--- a/tests/handlers/test_base_handler.py
+++ b/tests/handlers/test_base_handler.py
@@ -223,6 +223,48 @@ class ImagingOperationsTestCase(BaseImagingTestCase):
         expect(engine.size).to_equal((2000, 2600))
 
     @gen_test
+    async def test_svg_with_px_units_and_convert_to_png_with_size(self):
+        width, height = 400, 500
+        self.context.request = mock.Mock(width=width, height=height)
+        response = await self.async_fetch(
+            f"/unsafe/{width}x{height}/Commons-logo.svg"
+        )
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_png()
+
+        engine = Engine(self.context)
+        engine.load(response.body, ".png")
+        expect(engine.size).to_equal((width, height))
+
+    @gen_test
+    async def test_svg_with_inch_units_and_convert_to_png_with_size(self):
+        width, height = 400, 500
+        self.context.request = mock.Mock(width=width, height=height)
+        response = await self.async_fetch(
+            f"/unsafe/{width}x{height}/Commons-logo-inches.svg"
+        )
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_png()
+
+        engine = Engine(self.context)
+        engine.load(response.body, ".png")
+        expect(engine.size).to_equal((width, height))
+
+    @gen_test
+    async def test_svg_with_px_units_and_convert_to_png_with_width(self):
+        width = 300
+        self.context.request = mock.Mock(width=width)
+        response = await self.async_fetch(
+            f"/unsafe/fit-in/{width}x/Commons-logo.svg"
+        )
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_png()
+
+        engine = Engine(self.context)
+        engine.load(response.body, ".png")
+        expect(engine.size).to_equal((width, 403))
+
+    @gen_test
     async def test_can_read_8bit_tiff_as_png(self):
         response = await self.async_fetch("/unsafe/gradient_8bit.tif")
         expect(response.code).to_equal(200)

--- a/thumbor/engines/__init__.py
+++ b/thumbor/engines/__init__.py
@@ -173,7 +173,10 @@ class BaseEngine:
 
         try:
             buffer = cairosvg.svg2png(  # pylint: disable=no-member
-                bytestring=buffer, dpi=self.context.config.SVG_DPI
+                bytestring=buffer,
+                dpi=self.context.config.SVG_DPI,
+                output_width=self.context.request.width,
+                output_height=self.context.request.height,
             )
             mime = self.get_mimetype(buffer)
             self.extension = EXTENSION.get(mime, ".jpg")


### PR DESCRIPTION
CairoSVG allows setting output image width and height, but they were unused. This caused issues with some SVG images in px units to be of very bad quality after conversion. [Example](https://assets.htmlacademy.ru/content/blog/113/svg/pikachu.svg) of such image will have 127x127 size after conversion, based on `viewBox="0 0 127.782 127.782"` of file.

This PR will allow us to set up the output px dimensions of input SVG images in all units.